### PR TITLE
Change to properly detect ARM hardware

### DIFF
--- a/platformDetect.sh
+++ b/platformDetect.sh
@@ -6,7 +6,8 @@
 #
 
 # Pull the CPU Model from /proc/cpuinfo
-modelName=$(grep 'model name' /proc/cpuinfo | sed 's/.*: //')
+#modelName=$(grep 'model name' /proc/cpuinfo | sed 's/.*: //')
+modelName=$(lscpu | grep -o ARM)
 hardwareField=$(grep 'Hardware' /proc/cpuinfo | sed 's/.*: //')
 
 if [ -f /proc/device-tree/model ]; then


### PR DESCRIPTION
 Fix Platform Detection for ARM64 hardware; kernel changes has altered the output of /proc/cpuinfo: it not longer reports "ARM compatible" model name for arch64 processors;   reference: <https://github.com/raspberrypi/linux/issues/3991>.   Kernel change introduced in Bullseye 3-4 months ago but has just now been ported to Buster kernel and is effecting Pi4's dashboard displays: "Generic unknown class computer".  Tested on Pi0-Pi4B+ systems running Buster and Bullseye versions of Pi-Star.